### PR TITLE
Add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export function getAssetURL(asset: string): string;


### PR DESCRIPTION
I realized the only exported function from the main index file seems to be one function so I just made a quick definition file, just to fix the import errors in the examples. Everything else seems to be internal and does not really need to be typed yet for the consumer of the package. Maybe a starting place for #29 before (if) it gets converted to TypeScript.