### PR TITLE
fix: refactor getAssetURL to not use deprecated url method

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     runs-on: ubuntu-latest
     steps:

--- a/packages/electron-snowpack/index.js
+++ b/packages/electron-snowpack/index.js
@@ -1,12 +1,7 @@
-const url = require('url');
 const path = require('path');
 
 exports.getAssetURL = (asset) => {
   return process.env.NODE_ENV !== 'production'
     ? new URL(asset, `http://localhost:${process.env.SNOWPACK_PORT}/`).toString()
-    : url.format({
-        pathname: path.join(__dirname, asset),
-        protocol: 'file',
-        slashes: true,
-      });
+    : new URL(`file:///${path.join(__dirname, asset)}`).href;
 };

--- a/packages/electron-snowpack/package.json
+++ b/packages/electron-snowpack/package.json
@@ -30,6 +30,6 @@
     "snowpack": "^3.0.11"
   },
   "peerDependencies": {
-    "electron": "^11.0.0"
+    "electron": "*"
   }
 }


### PR DESCRIPTION
https://github.com/karolis-sh/electron-snowpack/issues/37