### PR TITLE
feat: update esbuild config to support building multiple files for main

### DIFF
--- a/packages/electron-snowpack/lib/get-esbuild-config.js
+++ b/packages/electron-snowpack/lib/get-esbuild-config.js
@@ -30,8 +30,8 @@ module.exports = async (more) => {
   return {
     platform: 'node',
     format: 'cjs',
-    entryPoints: await promisify(glob)('src/main/index.[jt]s'),
-    outfile: path.join(config.outputDir, 'main/index.js'),
+    entryPoints: await promisify(glob)('src/main/**/*.ts'),
+    outdir: path.join(config.outputDir, 'main'),
     bundle: true,
     external: ['electron'],
     define,

--- a/packages/electron-snowpack/lib/get-esbuild-config.js
+++ b/packages/electron-snowpack/lib/get-esbuild-config.js
@@ -30,7 +30,7 @@ module.exports = async (more) => {
   return {
     platform: 'node',
     format: 'cjs',
-    entryPoints: await promisify(glob)('src/main/**/*.ts'),
+    entryPoints: await promisify(glob)('src/main/@(index|preload).[jt]s'),
     outdir: path.join(config.outputDir, 'main'),
     bundle: true,
     external: ['electron'],


### PR DESCRIPTION
Electron noticed [the plan](https://www.electronjs.org/docs/breaking-changes#default-changed-contextisolation-defaults-to-true) that it will limit the direct access to the node components such as `require()` and `process.env` from v12.

So some electron users are supposed to set `nodeIntegration: false`, `contextIsolation: true` and `preload: 'preload.js'` for `webPreferences` of the window.

The current esbuild configuration is only for a single entry point (`main/index.ts`). So it is not able to build additional files like `preload.js`. This PR make it supports building multiple files for main.