### PR TITLE
feat: support passing electron arguments for dev command

### DIFF
--- a/packages/electron-snowpack/bin/cli.js
+++ b/packages/electron-snowpack/bin/cli.js
@@ -27,10 +27,11 @@ program
 program
   .command('dev')
   .description('Develop your project locally')
-  .action(() => {
+  .option('-- <args...>', 'electron arguments')
+  .action((options, command) => {
     process.env.NODE_ENV = 'development';
     require('../lib/init-env');
-    require('../lib/command/dev')();
+    require('../lib/command/dev')(program.args.filter((arg) => arg !== command.name()));
   });
 
 program

--- a/packages/electron-snowpack/lib/command/dev.js
+++ b/packages/electron-snowpack/lib/command/dev.js
@@ -19,11 +19,11 @@ const getMain = () => {
       if (electron && !electron.killed) electron.kill();
       if (esbuild) esbuild.rebuild.dispose();
     },
-    dev: async () => {
+    dev: async (electronArgs) => {
       let restarting = false;
 
       const startElectron = async () => {
-        const args = [path.join(config.outputDir, 'main/index.js')];
+        const args = [path.join(config.outputDir, 'main/index.js'), ...electronArgs];
         log.info(
           `Starting an ${chalk.bold('electron')} process with arguments: ${log.stringify(args)}`,
           { verbose: true }
@@ -90,7 +90,7 @@ const getRenderer = () => {
   };
 };
 
-module.exports = async () => {
+module.exports = async (electronArgs) => {
   const main = getMain();
   const renderer = getRenderer();
 
@@ -110,7 +110,7 @@ module.exports = async () => {
 
   try {
     await renderer.dev();
-    await main.dev();
+    await main.dev(electronArgs);
   } catch (err) {
     log.error(err);
     process.exit(1);

--- a/playground/playground/package.json
+++ b/playground/playground/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "electron-snowpack build",
     "clean": "rm -rf node_modules/.cache/snowpack; electron-snowpack clean",
-    "dev": "electron-snowpack dev",
+    "dev": "electron-snowpack dev -- --enable-logging --js-flags='--use-strict'",
     "dist": "electron-builder",
     "dist:dir": "yarn dist --dir -c.compression=store -c.mac.identity=null",
     "open": "open dist/mac/playground.app",


### PR DESCRIPTION
Adds support for the `-- <args...>` option on the `dev` command, and passes the remainder of the arguments (similar to `npm start`) to the underlying electron CLI executable.

This allows for passing arguments to the `main.js` in case the app supports processing CLI arguments.

- Example 1:  
  `electron-snowpack dev --verbose -- --myarg example -e=example --example2 'example 2'`
- Example 2 (with `electron-snowpack dev` as the `start` script in `package.json`):  
  `npm start -- --verbose -- --myarg example -e=example --example2 'example 2'`

The commander implementation automatically removes consumed arguments from the `program.args` array (like the `--verbose` in the previous example, and adds any "unconsumed" arguments after `--` to the args property. The command name needs to be explicitly removed.