### PR TITLE
Fix(windows): Kill electron subprocess when main process exits.

### DIFF
--- a/packages/electron-snowpack/lib/command/dev.js
+++ b/packages/electron-snowpack/lib/command/dev.js
@@ -28,7 +28,7 @@ const getMain = () => {
           `Starting an ${chalk.bold('electron')} process with arguments: ${log.stringify(args)}`,
           { verbose: true }
         );
-        electron = execa('electron', args);
+        electron = execa('electron', args, { windowsHide: false });
         electron.stdout.on('data', (message) => {
           log.info(message, { label: 'electron' });
         });


### PR DESCRIPTION
On Windows, the current behavior is that when killing the `electron-snowpack dev` process, the electron process spawned by execa does not exit, and is left running indefinitely. This is documented in this issue: https://github.com/sindresorhus/execa/issues/433

This fix copies the change which was applied to snowpack's `plugin-build-script` and `plugin-run-script` packages in https://github.com/snowpackjs/snowpack/pull/1022.